### PR TITLE
TWG-172: Fix shellcheck errors

### DIFF
--- a/scripts/install-darwin-multi-user.sh
+++ b/scripts/install-darwin-multi-user.sh
@@ -153,7 +153,7 @@ subheader() {
 }
 
 row() {
-    printf "$BOLD%s$ESC:\t%s\n" "$1" "$2"
+    printf "$BOLD%s$ESC:\\t%s\\n" "$1" "$2"
 }
 
 task() {
@@ -218,7 +218,7 @@ __sudo() {
 
     echo "I am executing:"
     echo ""
-    printf "    $ sudo %s\n" "$cmd"
+    printf "    $ sudo %s\\n" "$cmd"
     echo ""
     echo "$expl"
     echo ""


### PR DESCRIPTION
Builds against nixpkgs 18.03 failed with the following shellcheck errors:

```
<3>
<3>In /build/install-darwin-multi-user line 156:
<3>    printf "$BOLD%s$ESC:\t%s\n" "$1" "$2"
<3>                        ^-- SC1117: Backslash is literal in "\t". Prefer explicit escaping: "\\t".
<3>                            ^-- SC1117: Backslash is literal in "\n". Prefer explicit escaping: "\\n".
<3>
<3>
<3>In /build/install-darwin-multi-user line 221:
<3>    printf "    $ sudo %s\n" "$cmd"
<3>                         ^-- SC1117: Backslash is literal in "\n". Prefer explicit escaping: "\\n".
<3>
<3>builder for '/nix/store/z993g7rh3xq1kc3nwx3pkja8977mz7ml-nix-binary-tarball-1.11.15pre4524_94c94253.drv' failed with exit code 1
```